### PR TITLE
made edits to multiple files during debugging (just Py2 -> Py3 stuff)

### DIFF
--- a/hpsandbox/Chain.py
+++ b/hpsandbox/Chain.py
@@ -1,6 +1,5 @@
-#! /usr/bin/python
 #
-# Chain.py 	
+# Chain.py
 #
 # HISTORY
 #     5/28/2007 - Added docstrings
@@ -17,13 +16,13 @@ import os
 #########################################################################
 
 class Chain:
-    """An object to represent the 2D HP lattice chain and its attributes, with method functions.""" 
+    """An object to represent the 2D HP lattice chain and its attributes, with method functions."""
 
     def __init__(self,config):
-        """Initialize the Chain object."""    
+        """Initialize the Chain object."""
 
         print('\tInitializing Chain.py object...')
-        self.hpstring = string.strip(config.HPSTRING)	# The HP sequence as a string
+        self.hpstring = config.HPSTRING.strip()	# The HP sequence as a string
         self.n = len(self.hpstring)	                # the chain length
         self.hpbinary = self.hpstr2bin()                # The HP seq in binary rep (H=1 P=0)
 
@@ -42,7 +41,7 @@ class Chain:
         for i in range(0,self.n-1):
             self.vec.append(config.INITIALVEC[i])       # {0,1,2,3} =  {n,w,s,e} = {U,R,D,L}
 
-        self.coords = self.vec2coords(self.vec)         # the 2D coordinates of the chain, as a list of duples 
+        self.coords = self.vec2coords(self.vec)         # the 2D coordinates of the chain, as a list of duples
         self.viable = self.viability(self.coords)       # viable chains are ones which are self-avoiding
                                                         #     1 if viable, 0 if not
 
@@ -55,24 +54,24 @@ class Chain:
         self.nextcoords = []
         for i in range(0,len(self.coords)):
             self.nextcoords.append(self.coords[i])
-    
+
         self.nextviable = self.viable
 
 
     def hpstr2bin(self):
-        """Convert a string of type 'HPHPHPPPHHP' to a list of 1s and 0s.""" 
+        """Convert a string of type 'HPHPHPPPHHP' to a list of 1s and 0s."""
         binseq = []
         for i in range(0,len(self.hpstring)):
             if self.hpstring[i] == 'H':
-                binseq.append(1)   	
+                binseq.append(1)
             else:
-                binseq.append(0)   	
+                binseq.append(0)
         return binseq
 
 
 
     def vec2coords(self,thisvec):
-        """Convert a list of chain vectors to a list of coordinates (duples).""" 
+        """Convert a list of chain vectors to a list of coordinates (duples)."""
         tmp = [(0,0)]
         x = 0
         y = 0
@@ -86,7 +85,7 @@ class Chain:
             if thisvec[i] == 3:
                 x = x - 1
             tmp.append((x,y))
-        return tmp	
+        return tmp
 
 
     def vec2str(self, vec):
@@ -119,7 +118,7 @@ class Chain:
                     if self.hpstring[d] == 'H':
                         if (abs(self.coords[c][0]-self.coords[d][0]) + abs(self.coords[c][1]-self.coords[d][1])) == 1:
                             contactstate.append((c,d))
-        return contactstate 
+        return contactstate
 
 
     def grow(self):
@@ -129,10 +128,10 @@ class Chain:
         self.vec.append(0)
 
         # ... update the coords
-        i = len(self.coords) - 1 
+        i = len(self.coords) - 1
         last_coord = self.coords[i]
         app_coord = (last_coord[0],last_coord[1]+1)
-        self.coords.append(app_coord) 
+        self.coords.append(app_coord)
 
         # ... update the viability
         if self.coords.count(app_coord) > 1:
@@ -154,26 +153,26 @@ class Chain:
         "3" vectors, this process is done recursively.
 
         Example:
-            [0,0,0,0] --> [0,0,0,1] 
-            [0,0,1,2] --> [0,0,1,3] 
-            [0,1,0,3] --> [0,1,1] 
+            [0,0,0,0] --> [0,0,0,1]
+            [0,0,1,2] --> [0,0,1,3]
+            [0,1,0,3] --> [0,1,1]
             [0,3,3,3] --> [1]
- 
+
         This operation is very useful for enumerating the full space of chain conformations.
         shift()  will also update the coords and the viability, accordingly.
 
         RETURN VALUES
-  
+
             returns 1 if its the last possible "shift" --> i.e. if it's all 3's, the search is done
             returns 0 otherwise
         """
 
-        # pop off all the trailing 3's		
+        # pop off all the trailing 3's
         while self.lastvec() == 3:
             self.vec.pop()	# update vec
             self.coords.pop()	# update coords
 
-            ### update viability	
+            ### update viability
             self.viable = 1
             for c in self.coords:
                 if self.coords.count(c) > 1:
@@ -186,10 +185,10 @@ class Chain:
 
         i = len(self.vec) - 1	# the last vec index
 
-        # Otherwise, increment the remaining non-"3" elements  
+        # Otherwise, increment the remaining non-"3" elements
         if self.vec[i] == 0:
-            # update vec 
-            self.vec[i] = self.vec[i] + 1    
+            # update vec
+            self.vec[i] = self.vec[i] + 1
             # update coords: rotate "up" to "right"
             self.coords[i+1] = (self.coords[i+1][0] + 1,self.coords[i+1][1] - 1)
             # update viability
@@ -198,8 +197,8 @@ class Chain:
                 self.viable = 0
 
         elif self.vec[i] == 1:
-            # update vec 
-            self.vec[i] = self.vec[i] + 1    
+            # update vec
+            self.vec[i] = self.vec[i] + 1
             # update coords: rotate "right" to "down"
             self.coords[i+1] = (self.coords[i+1][0] - 1,self.coords[i+1][1] - 1)
             # update viability
@@ -208,8 +207,8 @@ class Chain:
                 self.viable = 0
 
         else:	# i.e. self.vec[i] == 2:
-            # update vec 
-            self.vec[i] = self.vec[i] + 1    
+            # update vec
+            self.vec[i] = self.vec[i] + 1
             # update coords: rotate "down" to "left"
             self.coords[i+1] = (self.coords[i+1][0] - 1,self.coords[i+1][1] + 1)
             # update viability
@@ -228,14 +227,14 @@ class Chain:
 
         nonsym() returns 1 if the vec list is non-symmetric, 0 otherwise
         """
-        
+
         if len(self.vec) > 0:
             # walk along chain until you get to the first non '0' vec:
             i = 0
             while (self.vec[i] == 0) & (i < len(self.vec) - 1) :
                 i = i + 1
-            if self.vec[0] == 0:	
-                if (self.vec[i] == 1) | (self.vec[i] == 0): 	
+            if self.vec[0] == 0:
+                if (self.vec[i] == 1) | (self.vec[i] == 0):
                     return(1)
 
         return(0)

--- a/hpsandbox/Config.py
+++ b/hpsandbox/Config.py
@@ -1,11 +1,11 @@
-# Config.py     
-#       
+# Config.py
+#
 # HISTORY:
 #
 #     5/25/2007 - cleanup for hp module, added read_configfile when initialized
 #     9/--/2005 - now reads in a configfile a la ZIPSEARCH
 #     9/19/2005 - added self.STOPATNATIVE
-#       
+#
 
 import string
 import pickle
@@ -22,7 +22,7 @@ class Config:
 
     # Important constants, energy parms
     self.randseed = 345                     # random seed for random.Random()
-    self.k =  0.001987                      # (kcal/K.mol) Boltzmann's constant 
+    self.k =  0.001987                      # (kcal/K.mol) Boltzmann's constant
     self.T = 300.0                          # reference temperataure units Kelvin (K)
     self.eps = -5.0                         # energetic strength of each contact (in units kT)
     self.epsilon = self.eps*self.k*self.T   # energetic strength of each contact -- in units Joules (J/mol)
@@ -37,7 +37,7 @@ class Config:
     self.REPLICATEMPS = [275.0, 300.0, 325.0, 350.0, 400.0, 450.0, 500.0, 600.0]
                                             # NOTE:  len(REPLICATEMPS) must equal NREPLICAS
     self.MCSTEPS = 500000                   # The number of Monte Carlo steps to perform
-    self.SWAPEVERY = 500000                 # The frequency with which to attempt replica swaps 
+    self.SWAPEVERY = 500000                 # The frequency with which to attempt replica swaps
     self.SWAPMETHOD = 'random pair'         # The method by which to select pairs of replicas for swaps
                                             #     options: 'random pair', and 'neighbors'
     self.MOVESET = 'MS2'                    # The type of Monte Carlo moveset
@@ -46,8 +46,8 @@ class Config:
 
     self.PRINTEVERY = 1000                  # Frequency (in MC steps) to print status info to screen
     self.TRJEVERY = 1000                    # Frequency (in MC steps) to write trajectory data to file
-    self.ENEEVERY = 1000                    # Frequenct (in MC steps) to write energy data to file 
-    
+    self.ENEEVERY = 1000                    # Frequenct (in MC steps) to write energy data to file
+
     self.STOPATNATIVE = 1                   # 1 to stop the simulation as soon as the native is found, 0 if not.
 
 
@@ -56,11 +56,11 @@ class Config:
     self.SETUPDIR = self.EXPDIR + '/setup'
     self.ANALDIR = self.EXPDIR + '/anal'
     self.DATADIR = self.EXPDIR + '/data'
-   
+
     # Directory pathname where files of type 'HPPHPHPHPPHP.clist' are located
-    # each belonging to a foldable sequence, and containing the native contact list 
+    # each belonging to a foldable sequence, and containing the native contact list
     self.NATIVEDIR = '/home6/voelzv/zippers/native/lattice/clist/hp13'
-    
+
     if filename != None:
         self.read_configfile( filename )
         self.filename = filename
@@ -72,67 +72,67 @@ class Config:
     """Read in configuration parameters from file.  The file should have formatted rows
     consisting of two fields, separated by white-space (or any non-printing characters, like tabs):
 
-    HPSTRING              PHPPHPPPHP 
+    HPSTRING              PHPPHPPPHP
     INITIALVEC           [0,0,0,0,0,0,0,0,0,0]
     ....
-    """ 
+    """
     print('\n#--------------Reading non-default Config.py file...--------------#')
-    
+
     fin = open(filename)
     lines = fin.readlines()
-    
+
     i = 0
     for i in range(0,len(lines)):
-        
-        fields = string.splitfields(lines[i])
+
+        fields = lines[i].split()
         if len(fields)>0:
 
             # Parse the variable assignments from the dummy Config file
             if fields[0] == 'HPSTRING':
                 self.HPSTRING = fields[1]
-    
+
             if fields[0] == 'INITIALVEC':
-                self.INITIALVEC = eval(string.joinfields(fields[1:]))
-    
+                self.INITIALVEC = eval("".join(fields[1:]))
+
             if fields[0] == 'randseed':
                 self.randseed = eval(fields[1])
-    
+
             if fields[0] == 'eps':
                 self.eps = eval(fields[1])
-    
+
             if fields[0] == 'RESTRAINED_STATE':
-               self.RESTRAINED_STATE = eval(string.joinfields(fields[1:]))
-    
+               self.RESTRAINED_STATE = eval("".join(fields[1:]))
+
             if fields[0] == 'KSPRING':
                self.KSPRING = eval(fields[1])
-    
+
             if fields[0] == 'NREPLICAS':
                 self.NREPLICAS = eval(fields[1])
-    
+
             if fields[0] == 'REPLICATEMPS':
-                self.REPLICATEMPS = eval(string.joinfields(fields[1:]))
-    
+                self.REPLICATEMPS = eval("".join(fields[1:]))
+
             if fields[0] == 'MCSTEPS':
                 self.MCSTEPS = eval(fields[1])
-    
+
             if fields[0] == 'SWAPEVERY':
                 self.SWAPEVERY = eval(fields[1])
-    
+
             if fields[0] == 'SWAPMETHOD':
-                self.SWAPMETHOD = string.joinfields(fields[1:])
-    
+                self.SWAPMETHOD = "".join(fields[1:])
+
             if fields[0] == 'MOVESET':
-                self.MOVESET = string.joinfields(fields[1:])
-    
+                self.MOVESET = "".join(fields[1:])
+
             if fields[0] == 'EXPDIR':
-                self.EXPDIR = string.joinfields(fields[1:])
-    
+                self.EXPDIR = "".join(fields[1:])
+
             if fields[0] == 'PRINTEVERY':
                 self.PRINTEVERY = eval(fields[1])
-    
+
             if fields[0] == 'TRJEVERY':
                 self.TRJEVERY = eval(fields[1])
-    
+
             if fields[0] == 'ENEEVERY':
                 self.ENEEVERY = eval(fields[1])
 
@@ -142,13 +142,13 @@ class Config:
             if fields[0] == 'STOPATNATIVE':
                 self.STOPATNATIVE = eval(fields[1])
 
-    
+
     # end of line-reading loop
-    
+
     self.SETUPDIR = self.EXPDIR + '/setup'
     self.ANALDIR = self.EXPDIR + '/anal'
     self.DATADIR = self.EXPDIR + '/data'
-    
+
     self.epsilon = self.eps*self.k*self.T
 
 

--- a/hpsandbox/Replica.py
+++ b/hpsandbox/Replica.py
@@ -1,6 +1,5 @@
-#! /usr/bin/python
 #
-# Replica.py    
+# Replica.py
 
 #from Config import *
 #import Chain
@@ -12,6 +11,8 @@ import string
 import math
 import sys
 import os
+from .Chain import Chain
+from .Monty import Monty
 
 class Replica:
     """A container object, to hold the Chain() and Monty() objects"""
@@ -21,8 +22,8 @@ class Replica:
 
         temp = config.REPLICATEMPS[repnum]
         self.repnum = repnum
-        self.repname = 'rep' + string.zfill(str(repnum),2)
+        self.repname = 'rep' + str(repnum).zfill(2)
         self.repdir = config.DATADIR + self.repname
-        self.chain = Chain.Chain(config)
-        self.mc = Monty.Monty(config,temp,self.chain)    
-    
+        self.chain = Chain(config)
+        self.mc = Monty(config,temp,self.chain)
+


### PR DESCRIPTION
Changes have been made to clean up the conversion from Py2 to Py3. For example, method calls like `string.splitfields(var)` that are no longer implemented in Py3 have been converted to `str(var).split()` 
All changes in this PR only reflect the bugs found from the notebook:
[enumerate12mer-6parms-distances](https://github.com/vvoelz/HPSandbox/tree/master/examples/enumerate12mer-6parms-distances)/enum_microstates.ipynb

Please note that other issues may still exist.  